### PR TITLE
Include commitId.txt in archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ NashornProfile.txt
 /src/utils/LogCompilation/target/
 /.project/
 /.settings/
+commitId.txt

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -66,7 +66,7 @@ task copySource(type: Exec) {
             "${project.rootDir}/", buildRoot
 }
 
-/** 
+/**
  * Scan the patches folder for any .patch that needs
  * to be applied before start building.
  */
@@ -144,6 +144,7 @@ task packageBuildResults(type: Tar) {
         include 'ASSEMBLY_EXCEPTION'
         include 'LICENSE'
         include 'README.md'
+        include 'commitId.txt'
         include 'version.txt'
     }
     from(jdkResultingImage) {
@@ -156,7 +157,7 @@ task packageBuildResults(type: Tar) {
         include 'release'
         exclude '**/*.diz'
     }
-    
+
     // Copy legal directory specifically to set permission correctly.
     // See https://github.com/corretto/corretto-11/issues/129
     from(jdkResultingImage) {

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -133,6 +133,7 @@ task packageBuildResults(type: Tar) {
         include 'ASSEMBLY_EXCEPTION'
         include 'LICENSE'
         include 'README.md'
+        include 'commitId.txt'
         include 'version.txt'
         into project.correttoJdkArchiveName
     }

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -136,6 +136,15 @@ task prepareArtifacts {
                 include "Contents/MacOS/**"
                 exclude "Contents/Home/**/*.diz"
             }
+            from(buildRoot) {
+                include 'ADDITIONAL_LICENSE_INFO'
+                include 'ASSEMBLY_EXCEPTION'
+                include 'LICENSE'
+                include 'README.md'
+                include 'commitId.txt'
+                include 'version.txt'
+                into "Contents/Home"
+            }
             into "${buildDir}/${correttoMacDir}"
         }
         // Set the directory as bundle

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -97,11 +97,12 @@ task packageBuildResults(type: Zip) {
         exclude '**/*.diz'
     }
     from(buildRoot) {
+        include 'ADDITIONAL_LICENSE_INFO'
         include 'ASSEMBLY_EXCEPTION'
         include 'LICENSE'
+        include 'README.md'
+        include 'commitId.txt'
         include 'version.txt'
-        include 'ADDITIONAL_LICENSE_INFO'
-        include 'README'
     }
 }
 


### PR DESCRIPTION
Backport of the https://github.com/corretto/corretto-jdk/pull/91 to the corretto-20. It was integrated into the corretto-jdk after the fork of corretto-20.